### PR TITLE
Fix buffer overread in do_readlink

### DIFF
--- a/src/PathFind.cpp
+++ b/src/PathFind.cpp
@@ -65,7 +65,10 @@ string do_readlink(std::string const& path)
     ssize_t len = ::readlink(path.c_str(), buff, sizeof(buff)-1);
 #endif
 
-    return string(buff);
+    if ( len > 0 )
+        return string(buff, len);
+    else
+        return string();
 }
 
 string FindExecutable()


### PR DESCRIPTION
readlink does not return a 0-terminated string.

Fixes https://github.com/bkloppenborg/pathfind/issues/1