### PR TITLE
Fixes for compiling on VS 2022

### DIFF
--- a/src/pathfind.cpp
+++ b/src/pathfind.cpp
@@ -27,34 +27,34 @@ std::string PathFind::do_GetModuleFileNameW(int max_path)
   WCHAR buff[max_path + 1];
   memset(buff, '\0', max_path + 1);
 
-	HMODULE hModule = GetModuleHandleW(NULL);
-	GetModuleFileNameW(hModule, buff, max_path);
+  HMODULE hModule = GetModuleHandleW(NULL);
+  GetModuleFileNameW(hModule, buff, max_path);
 #else
   char buff[max_path + 1];
   memset(buff, '\0', max_path + 1);
 #endif
 
-	return std::string(buff);
+  return std::string(buff);
 }
 
 std::string PathFind::do_NSGetExecutablePath(int max_path)
 {
-	char buff[max_path + 1];
+  char buff[max_path + 1];
   memset(buff, '\0', max_path + 1);
 
 #if defined(__APPLE__) || defined(MACOSX) // Apple / OSX
-	uint32_t max_path_ = max_path;
-	assert(static_cast<int>(max_path_) == max_path && "max_path is not representable");
-	_NSGetExecutablePath(buff, &max_path_);
+  uint32_t max_path_ = max_path;
+  assert(static_cast<int>(max_path_) == max_path && "max_path is not representable");
+  _NSGetExecutablePath(buff, &max_path_);
 #endif
 
-	return std::string(buff);
+  return std::string(buff);
 }
 
 std::string PathFind::do_readlink(std::string const& path, int max_path)
 {
   // allocate a buffer in which to store the path.
-	char buff[max_path + 1];
+  char buff[max_path + 1];
   memset(buff, '\0', max_path + 1);
 
 #if defined(BSD) || defined(__gnu_linux__) || defined(__linux__) || defined(sun) || defined(__sun)
@@ -67,8 +67,7 @@ std::string PathFind::do_readlink(std::string const& path, int max_path)
 /// Find the path to the current executable
 std::string PathFind::FindExecutable(int max_path)
 {
-
-	std::string path("");
+  std::string path("");
 
   // Enforce maximum path length limit on Windows.
 #if defined (WIN32)
@@ -77,17 +76,17 @@ std::string PathFind::FindExecutable(int max_path)
 #endif
 
   // OS-specific calls to find the path to the current executable.
-#if defined (__APPLE__) || defined(MACOSX)	// Apple / OSX
-	path = PathFind::do_NSGetExecutablePath(max_path);
+#if defined (__APPLE__) || defined(MACOSX)  // Apple / OSX
+  path = PathFind::do_NSGetExecutablePath(max_path);
 #elif defined (WIN32) // Windows
-	path = PathFind::do_GetModuleFileNameW(max_path);
+  path = PathFind::do_GetModuleFileNameW(max_path);
 #elif defined (BSD) // BSD variants
-	path = PathFind::do_readlink("/proc/curproc/file", max_path);
+  path = PathFind::do_readlink("/proc/curproc/file", max_path);
 #elif defined (sun) || defined(__sun) // Solaris
-	path = PathFind::do_readlink("/proc/self/path/a.out", max_path);
-#elif defined (__gnu_linux__)	|| defined (__linux__)// Linux
-	path = PathFind::do_readlink("/proc/self/exe", max_path);
+  path = PathFind::do_readlink("/proc/self/path/a.out", max_path);
+#elif defined (__gnu_linux__)  || defined (__linux__)// Linux
+  path = PathFind::do_readlink("/proc/self/exe", max_path);
 #endif
 
-	return path;
+  return path;
 }

--- a/src/pathfind.cpp
+++ b/src/pathfind.cpp
@@ -23,51 +23,62 @@
 
 std::string PathFind::do_GetModuleFileNameW(int max_path)
 {
+  std::string ret;
+
 #if defined (WIN32) // Windows
   TCHAR buff[MAX_PATH];
   memset(buff, '\0', max_path);
 
   HMODULE hModule = GetModuleHandle(NULL);
   GetModuleFileName(hModule, buff, max_path);
-#else
-  char buff[max_path + 1];
-  memset(buff, '\0', max_path + 1);
+
+  ret = std::move(std::string(buff));
 #endif
 
-  return std::string(buff);
+  return ret;
 }
 
 std::string PathFind::do_NSGetExecutablePath(int max_path)
 {
-  char buff[max_path + 1];
-  memset(buff, '\0', max_path + 1);
+  std::string ret;
 
 #if defined(__APPLE__) || defined(MACOSX) // Apple / OSX
+  char* buff = new char[max_path + 1];
+  memset(buff, '\0', max_path + 1);
+
   uint32_t max_path_ = max_path;
   assert(static_cast<int>(max_path_) == max_path && "max_path is not representable");
   _NSGetExecutablePath(buff, &max_path_);
+
+  ret = std::move(std::string(buff));
+  delete[] buff;
 #endif
 
-  return std::string(buff);
+  return ret;
 }
 
 std::string PathFind::do_readlink(std::string const& path, int max_path)
 {
   // allocate a buffer in which to store the path.
-  char buff[max_path + 1];
-  memset(buff, '\0', max_path + 1);
+  std::string ret;
 
 #if defined(BSD) || defined(__gnu_linux__) || defined(__linux__) || defined(sun) || defined(__sun)
+  char* buff = new char[max_path + 1];
+  memset(buff, '\0', max_path + 1);
+
   size_t len = ::readlink(path.c_str(), buff, max_path);
+
+  ret = std::move(std::string(buff));
+  delete[] buff;
 #endif
 
-  return std::string(buff);
+  return ret;
 }
 
 /// Find the path to the current executable
 std::string PathFind::FindExecutable(int max_path)
 {
-  std::string path("");
+  std::string path;
 
   // OS-specific calls to find the path to the current executable.
 #if defined (__APPLE__) || defined(MACOSX)  // Apple / OSX

--- a/src/pathfind.cpp
+++ b/src/pathfind.cpp
@@ -24,11 +24,11 @@
 std::string PathFind::do_GetModuleFileNameW(int max_path)
 {
 #if defined (WIN32) // Windows
-  WCHAR buff[max_path + 1];
-  memset(buff, '\0', max_path + 1);
+  TCHAR buff[MAX_PATH];
+  memset(buff, '\0', max_path);
 
-  HMODULE hModule = GetModuleHandleW(NULL);
-  GetModuleFileNameW(hModule, buff, max_path);
+  HMODULE hModule = GetModuleHandle(NULL);
+  GetModuleFileName(hModule, buff, max_path);
 #else
   char buff[max_path + 1];
   memset(buff, '\0', max_path + 1);
@@ -68,12 +68,6 @@ std::string PathFind::do_readlink(std::string const& path, int max_path)
 std::string PathFind::FindExecutable(int max_path)
 {
   std::string path("");
-
-  // Enforce maximum path length limit on Windows.
-#if defined (WIN32)
-  if(MAX_PATH < max_path)
-    max_path = MAX_PATH;
-#endif
 
   // OS-specific calls to find the path to the current executable.
 #if defined (__APPLE__) || defined(MACOSX)  // Apple / OSX

--- a/src/pathfind.hpp
+++ b/src/pathfind.hpp
@@ -20,7 +20,7 @@
 #if defined (__APPLE__) || defined(MACOSX)	// Apple
 #include <mach-o/dyld.h>
 #elif defined (WIN32) // Windows
-// No includes necessary?
+#include <windows.h>
 #elif defined (BSD) || defined(__gnu_linux__) || defined(__linux__) || defined(sun) || defined(__sun)	 // BSD, Linux, Solaris
 #include <unistd.h>
 #endif


### PR DESCRIPTION
The primary drive here is to make it compile again but there's also some minor whitespace cleanup. The one caveat is that it uses `GetModuleFileName` instead of `GetModuleFileNameW`, which loses the ability to lookup paths with wide characters. There's an issue there anyways because the methods are returning `std::string`, and it'd have to convert from `WCHAR` to `std::wstring` to `std::string` anyways, thus losing the wide character support anyways.

I've tested this on Windows, macOS, and ArchLinux and the example application was working correctly on all three of them.