### PR TITLE
A few more minor updates for Windows

### DIFF
--- a/src/pathfind.cpp
+++ b/src/pathfind.cpp
@@ -26,13 +26,11 @@ std::string PathFind::do_GetModuleFileNameW(int max_path)
   std::string ret;
 
 #if defined (WIN32) // Windows
-  TCHAR buff[MAX_PATH];
-  memset(buff, '\0', max_path);
-
+  TCHAR buff[MAX_PATH]{};
   HMODULE hModule = GetModuleHandle(NULL);
-  GetModuleFileName(hModule, buff, max_path);
+  GetModuleFileNameA(hModule, buff, max_path);
 
-  ret = std::move(std::string(buff));
+  ret = buff;
 #endif
 
   return ret;


### PR DESCRIPTION
After a bit more testing with an actual application using the pathfind library, this fixes:

- AddressSanitizer complaining about the length of the `memset`,
- Explicitly calling `GetModuleFileNameA` instead of leaving it up to type deduction
- Removing the unneeded calls to std::move and the explicit construction of a std::string temporary